### PR TITLE
Added support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: C
+install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -y libgmp-dev
+    - sudo apt-get install -y libmpfr-dev
+    - sudo apt-get install -y g++
+    - bash scripts/build_cross_compiler.sh
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
-language: C
+# Make sure we run in the docker container
+sudo: false
+language: c
 addons:
     apt:
         packages:
-        - libgmp-dev
-        - libmpfr-dev
+        # Libraries needed to build cross compiler
+            - libgmp-dev
+            - libmpfr-dev
 cache:
     apt: true
-    #directories:
-    #    - compiler/
-#install: bash scripts/build_cross_compiler.sh
+    directories:
+        - compiler/
+# Compiles the cross compiler into the projects root
+before_install: bash scripts/build_cross_compiler.sh
 script:
+    - make
     - make run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 # Make sure we run in the docker container
 sudo: false
 language: c
-addons:
-    apt:
-        packages:
-        # Libraries needed to build cross compiler
-            - libgmp-dev
-            - libmpfr-dev
 cache:
-    apt: true
     directories:
         - compiler/
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ addons:
         packages:
         - libgmp-dev
         - libmpfr-dev
-install: bash scripts/build_cross_compiler.sh
 cache:
     apt: true
-    directories:
-        - compiler/
-script: make
+    #directories:
+    #    - compiler/
+#install: bash scripts/build_cross_compiler.sh
+script:
+    - make run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ cache:
     apt: true
     directories:
         - compiler/
-# Compiles the cross compiler into the projects root
-before_install: bash scripts/build_cross_compiler.sh
 script:
     - make
     - make run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: C
-install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y libgmp-dev
-    - sudo apt-get install -y libmpfr-dev
-    - sudo apt-get install -y g++
-    - bash scripts/build_cross_compiler.sh
+addons:
+    apt:
+        packages:
+        - libgmp-dev
+        - libmpfr-dev
+install: bash scripts/build_cross_compiler.sh
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,8 @@ addons:
         - libgmp-dev
         - libmpfr-dev
 install: bash scripts/build_cross_compiler.sh
+cache:
+    apt: true
+    directories:
+        - compiler/
 script: make

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ARCH=i686-elf
-TEST_CC=gcc
+TEST_CC=clang
 GCOV=gcov
 CC=compiler/$(ARCH)/bin/$(ARCH)-gcc
 AS=compiler/$(ARCH)/bin/$(ARCH)-as

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Kernel of Truth ![build_status](https://travis-ci.org/Herbstein/kernel-of-truth.svg?branch=master)
+Kernel of Truth ![build_status](https://travis-ci.org/iankronquist/kernel-of-truth.svg?branch=master)
 ===============
 
 A simple kernel written in C.


### PR DESCRIPTION
The build status image has to be changed to support the main repository and Ian will have to create the project on the [Travis CI website](https://travis-ci.org/). Build takes around 16 minutes to complete, which is way too long. This will need to be addressed.