### PR TITLE
Switch pages outside of switch task

### DIFF
--- a/kernel/arch/x86/process.c
+++ b/kernel/arch/x86/process.c
@@ -52,6 +52,7 @@ void preempt() {
     if (running_proc == last) {
         return;
     }
+    enable_paging((void*)running_proc->regs.cr3);
     switch_task(&last->regs, &running_proc->regs);
 }
 

--- a/kernel/arch/x86/process.s
+++ b/kernel/arch/x86/process.s
@@ -21,11 +21,6 @@ switch_task:
 	mov eax, cr3
 	push eax
 
-	mov		eax,	cr0
-	and		eax,	~0x80000000
-	mov		cr0,	eax
-
-
 	mov eax, [esp+44]
 	mov ebx, [4+eax]
 	mov ecx, [8+eax]
@@ -86,16 +81,7 @@ switch_task:
 	# esp
 	mov esp, [24+eax]
 
-	# cr3 (page directory)
 	push eax
-	mov eax, [40+eax]
-	mov cr3, eax
-
-	mov		eax,	cr0
-	or		eax,	0x80000000
-	mov		cr0,	eax
-
-	mov eax, [esp]
 
 	# eip
 	mov eax, [32+eax]


### PR DESCRIPTION
The kernel is mapped identically on both pages.