### PR TITLE
Get code coverage results for kmem and physical_allocator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
             - python-virtualenv
             - libclang1-3.4
             - nasm
+            - clang
 cache:
     directories:
         - compiler/
@@ -23,6 +24,7 @@ script:
     - if [[ ! -e compiler/i686-elf/bin/i686-elf-gcc ]]; then
         bash ./scripts/build_cross_compiler.sh;
       fi
+    - export PATH=$PATH:/home/travis/build/awensaunders/kernel-of-truth/compiler/i686-elf/bin
     - make
     - make run-tests
     - make docs

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ARCH=i686-elf
 TEST_CC=clang
-GCOV=gcov
+COV= llvm-cov
 GRUB_MKRESCUE=grub-mkrescue
 CC=env $(ARCH)-gcc
 AS=nasm
@@ -17,9 +17,9 @@ tests: build libk-tests
 
 run-tests: tests
 	./build/tests/kmem
-	${GCOV} kmem.gcno
+	${COV} -gcno kmem.gcno -gcda kmem.gcda -o kmem.cov
 	./build/tests/physical_allocator
-	${GCOV} physical_allocator.gcno
+	${COV} -gcno physical_allocator.gcno -gcda physical_allocator.gcda -o physical_allocator.cov
 
 bootloader-x86: build
 	${AS} kernel/arch/x86/boot.s -o build/boot.o ${ASFLAGS}

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ clean-all: clean
 	rm -f *.gcno
 	rm -f *.gcov
 	rm -f *.gcda
-
+	rm -f *.cov
 docs:
 	cldoc generate -I ./include -DARCH_X86 -Wno-int-to-pointer-cast -- --output build/docs kernel/libk/*.c kernel/arch/x86/*.c kernel/drivers/*.c include/libk/*.h include/drivers/*.h kernel/*.c include/arch/x86/*.h --language c --report
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ARCH=i686-elf
 TEST_CC=clang
 GCOV=gcov
 GRUB_MKRESCUE=grub-mkrescue
-CC=compiler/$(ARCH)/bin/$(ARCH)-gcc
+CC=env $(ARCH)-gcc
 AS=nasm
 ASFLAGS=-felf32 -F dwarf -g
 CFLAGS= -std=c11 -ffreestanding -O0 -Wall -Werror -Wextra -g -I ./include -I tlibc/include -D ARCH_X86

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |c|
   c.vm.provision "shell", inline: <<-SHELL
     echo 'export GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"' >> /home/vagrant/.bashrc
     sudo apt-get update
-    sudo apt-get install -y xorriso gdb nasm llvm grub-common qemu
+    sudo apt-get install -y xorriso gdb nasm llvm grub-common qemu g++ libisl-dev libcloog-isl-dev 
   SHELL
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |c|
   c.vm.provision "shell", inline: <<-SHELL
     echo 'export GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"' >> /home/vagrant/.bashrc
     sudo apt-get update
-    sudo apt-get install -y xorriso gdb nasm llvm grub-common qemu g++ libisl-dev libcloog-isl-dev 
+    sudo apt-get install -y xorriso gdb nasm llvm clang grub-common qemu g++ libisl-dev libcloog-isl-dev 
   SHELL
 
 end

--- a/scripts/build_cross_compiler.sh
+++ b/scripts/build_cross_compiler.sh
@@ -2,7 +2,7 @@
 
 TARGET=i686-elf
 PREFIX=$(pwd)/compiler/$TARGET
-PATH=$PATH:$PREFIX/bin
+PATH=$PREFIX/bin:$PATH
 CFLAGS=" -g -O2"
 # if we're on a mac, try our damndest to use real GCC not clang
 if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
Solves #14? 
I switched from using gcov to llvm-cov for code coverage tests. When make run-tests is invoked, it leaves kmem.cov and physical_allocator.cov in the project directory for analysis. 