### PR TITLE
Add simple test for documentation coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,3 @@ script:
       fi
     - make
     - make run-tests
-    - make docs

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,15 @@ TMP=/tmp
 
 all: build/truthos.bin
 
-tests: build/tests/kmem_tests build/tests/physical_allocator_tests
+tests: build/tests/kmem_tests build/tests/physical_allocator_tests docs-tests
+
+# Check that documentation coverage didn't change.
+# We don't care about enum values.
+docs-tests: docs
+	grep -E 'name="enum"\s+undocumented="0"' build/docs/xml/report.xml
+	grep -E 'name="typedef"\s+undocumented="0"' build/docs/xml/report.xml
+	grep -E 'name="struct"\s+undocumented="0"' build/docs/xml/report.xml
+	grep -E 'name="function"\s+undocumented="0"' build/docs/xml/report.xml
 
 run-tests: tests
 	./build/tests/kmem
@@ -146,4 +154,4 @@ start-virtualbox:
 	echo "Run VM"
 	${VB} --startvm TruthOS --dbg
 
-.PHONY: all clean clean-all start run start-virtualbox iso start-debug start-log tests run-tests
+.PHONY: all clean clean-all start run start-virtualbox iso start-debug start-log tests run-tests docs-tests

--- a/include/arch/x86/paging.h
+++ b/include/arch/x86/paging.h
@@ -44,29 +44,51 @@
 #define CUR_PAGE_DIRECTORY_ADDR ((uint32_t*)(0xfffff000))
 #define PAGING_DIR_PHYS_ADDR 0xffc00000
 
+// Set the current page table to the provided top level directory and enable
+// paging.
 extern void enable_paging(page_frame_t page_dir);
+// Disable paging.
 extern void disable_paging(void);
+// Do not change the page table, just flip the paging bit.
 extern void just_enable_paging(void);
+// Get the current page table directory.
 extern page_frame_t get_page_dir(void);
+// Flush the translation look-aside buffer.
 extern void flush_tlb(void);
 
+// Install the kernel page table.
 page_frame_t kernel_page_table_install(struct multiboot_info*);
 
+// Create a new page directory and map important data.
+// Map code at entrypoint, the code location, and the code's stack.
 page_frame_t create_page_dir(void *link_loc, void *stack_loc,
         void(*entrypoint)(), uint16_t permissions);
+// Find an unused physical address and map it.
+// Find a free virtual address in the paging directory, and map the provided
+// physical address with the given permissions.
 void *find_free_addr(uint32_t *page_dir, page_frame_t phys_addr,
         uint16_t permissions);
 
+// Identity map kernel.
 void map_kernel_pages(uint32_t *page_dir);
 
+// Map a page when paging is disabled.
+// Map a physical page in the page directory at the given virtual address with
+// permissions.
 int map_page(uint32_t *page_dir, page_frame_t physical_page,
         void *virtual_address, uint16_t permissions);
 
+// Unmap a page from a different page directory than the current one.
+// if should_free_frame is true, the resident page frame will be marked as
+// free.
 int inner_unmap_page(uint32_t *page_entries, void *virtual_address,
         bool should_free_frame);
 
+// Free a page table.
 void free_table(uint32_t *page_dir);
+// Map the kernel pages into a page table different than the current one.
 void inner_map_kernel_pages(uint32_t *page_dir);
+// Map a page into a different page table than the current one.
 int inner_map_page(uint32_t *page_dir, page_frame_t physical_page,
         void *virtual_address, uint16_t permissions);
 #endif


### PR DESCRIPTION
During a travis run, check that documentation coverage does not decrease.
Fixes #57.