### PR TITLE
Virt mem refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,12 @@ build/boot.o:
 
 build/libk.o: build/serial.o kernel/libk/*.c include/libk/*.h
 	${CC} -c kernel/libk/kmem.c -o ${TMP}/kmem.o  ${CFLAGS}
+	${CC} -c kernel/libk/vmem.c -o ${TMP}/vmem.o  ${CFLAGS}
 	${CC} -c kernel/libk/kabort.c -o ${TMP}/kabort.o  ${CFLAGS}
 	${CC} -c kernel/libk/kputs.c -o ${TMP}/kputs.o  ${CFLAGS}
 	${CC} -c kernel/libk/klog.c -o ${TMP}/klog.o  ${CFLAGS}
 	${CC} -c kernel/libk/physical_allocator.c -o ${TMP}/physical_allocator.o  ${CFLAGS}
-	${LD} -r ${TMP}/kmem.o ${TMP}/kabort.o ${TMP}/kputs.o ${TMP}/klog.o ${TMP}/physical_allocator.o -o build/libk.o ${LDFLAGS}
+	${LD} -r ${TMP}/kmem.o ${TMP}/kabort.o ${TMP}/kputs.o ${TMP}/klog.o ${TMP}/physical_allocator.o ${TMP}/vmem.o -o build/libk.o ${LDFLAGS}
 
 build/pci.o: kernel/drivers/pci.c include/drivers/pci.h
 	${CC} -c kernel/drivers/pci.c -o build/pci.o ${CFLAGS}

--- a/include/arch/x86/paging.h
+++ b/include/arch/x86/paging.h
@@ -63,14 +63,6 @@ page_frame_t kernel_page_table_install(struct multiboot_info*);
 // Map code at entrypoint, the code location, and the code's stack.
 page_frame_t create_page_dir(void *link_loc, void *stack_loc,
         void(*entrypoint)(), uint16_t permissions);
-// Find an unused physical address and map it.
-// Find a free virtual address in the paging directory, and map the provided
-// physical address with the given permissions.
-void *find_free_addr(uint32_t *page_dir, page_frame_t phys_addr,
-        uint16_t permissions);
-
-// Identity map kernel.
-void map_kernel_pages(uint32_t *page_dir);
 
 // Map a page when paging is disabled.
 // Map a physical page in the page directory at the given virtual address with
@@ -86,8 +78,6 @@ int inner_unmap_page(uint32_t *page_entries, void *virtual_address,
 
 // Free a page table.
 void free_table(uint32_t *page_dir);
-// Map the kernel pages into a page table different than the current one.
-void inner_map_kernel_pages(uint32_t *page_dir);
 // Map a page into a different page table than the current one.
 int inner_map_page(uint32_t *page_dir, page_frame_t physical_page,
         void *virtual_address, uint16_t permissions);

--- a/include/arch/x86/process.h
+++ b/include/arch/x86/process.h
@@ -11,23 +11,30 @@
 
 struct virt_region;
 
+// FIXME: Move to private architecture specific file.
+/* All of the memory structures used by a single process.
+ * This includes a virtual memory space cache, the kernel stack,
+ * the user stack, and the page tables.
+*/
+struct proc_mem {
+    page_frame_t page_dir;
+    void *kernel_stack;
+    void *user_stack;
+    struct virt_region *free_virt;
+};
+
 /* Represents a single process.
  * Processes are kept in a simple circularly linked list.
  *
  * @id: A single process id. Currently, process ids increase monotonically, and
  * will eventually loop around. However, do not rely on this behavior.
- * @user_esp: The stack used by user space programs.
- * @kernel_esp: The stack used by kernel space programs, including syscalls.
- * @cr3: The top level paging directory.
+ * @memory: All data required to describe and manage the process' memory.
  * @next: The next process to be run.
  */
 struct process {
-    uint32_t id;
-    uint32_t user_esp;
-    uint32_t kernel_esp;
-    uint32_t cr3;
-    struct virt_region *free_virt;
+    struct proc_mem memory;
     struct process *next;
+    uint32_t id;
 };
 
 /* Set up multi-processing.  */

--- a/include/arch/x86/process.h
+++ b/include/arch/x86/process.h
@@ -9,6 +9,8 @@
 
 #include <libk/kmem.h>
 
+struct virt_region;
+
 /* Represents a single process.
  * Processes are kept in a simple circularly linked list.
  *
@@ -24,6 +26,7 @@ struct process {
     uint32_t user_esp;
     uint32_t kernel_esp;
     uint32_t cr3;
+    struct virt_region *free_virt;
     struct process *next;
 };
 
@@ -41,5 +44,8 @@ void preempt(void);
 
 /* Schedule a process to be run. */
 void schedule_proc(struct process *proc);
+
+/* Get a pointer to the currently running process */
+struct process *get_current_proc(void);
 
 #endif

--- a/include/libk/vmem.h
+++ b/include/libk/vmem.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stddef.h>
+
+// A region of virtual memory.
+struct virt_region;
+
+// Permissions applied to virtual memory regions.
+// They can be combined with logical or. The values are taken from the bits in
+// x86 32 bit paging tables.
+enum region_perms {
+    REGION_WRITABLE      =  2,
+    REGION_USER_MODE     =  4,
+    REGION_WRITE_THROUGH =  8,
+    REGION_UNCACHED      = 16,
+};
+
+// Get a region of virtual memory.
+void *get_region(size_t pages, enum region_perms perms);
+
+// Return a region of virtual memory to the kernel.
+// It is up to the caller to ensure there are no leaks.
+void put_region(void *region, size_t pages);
+
+// Get a list of free virtual memory for a new address space.
+struct virt_region *init_free_list(void);

--- a/kernel/arch/x86/paging.c
+++ b/kernel/arch/x86/paging.c
@@ -1,5 +1,14 @@
 #include <arch/x86/paging.h>
 
+// Identity map kernel.
+static void map_kernel_pages(uint32_t *page_dir);
+// Map the kernel pages into a page table different than the current one.
+static void inner_map_kernel_pages(uint32_t *page_dir);
+
+// TODO: Remove this.
+static void *find_free_addr(uint32_t *page_entries, page_frame_t phys_addr,
+        uint16_t permissions);
+
 page_frame_t kernel_page_table_install(struct multiboot_info *mb) {
     // Certain very important things already exist in physical memory. They
     // need to be marked as present so that the allocator doesn't grab them by
@@ -100,7 +109,7 @@ page_frame_t create_page_dir(void *link_loc, void *stack_loc,
     return page_table;
 }
 
-void *find_free_addr(uint32_t *page_entries, page_frame_t phys_addr,
+static void *find_free_addr(uint32_t *page_entries, page_frame_t phys_addr,
         uint16_t permissions) {
     // Walk the page directory in search of an available address
     for (size_t i = 0; i < PAGE_TABLE_SIZE-1; ++i) {
@@ -135,7 +144,7 @@ void *find_free_addr(uint32_t *page_entries, page_frame_t phys_addr,
 }
 
 
-void map_kernel_pages(uint32_t *page_dir) {
+static void map_kernel_pages(uint32_t *page_dir) {
     map_page(page_dir, 0x100000, (void*)0x100000, 0);
     // Map all those important bits
     for (page_frame_t i = KERNEL_START; i < KERNEL_END; i += PAGE_SIZE) {
@@ -147,7 +156,7 @@ void map_kernel_pages(uint32_t *page_dir) {
     map_page(page_dir, VIDEO_MEMORY_BEGIN, (void*)VIDEO_MEMORY_BEGIN, 0);
 }
 
-void inner_map_kernel_pages(uint32_t *page_dir) {
+static void inner_map_kernel_pages(uint32_t *page_dir) {
     inner_map_page(page_dir, 0x100000, (void*)0x100000, 0);
     // Map all those important bits
     for (page_frame_t i = KERNEL_START; i < KERNEL_END; i += PAGE_SIZE) {

--- a/kernel/arch/x86/process.c
+++ b/kernel/arch/x86/process.c
@@ -5,7 +5,6 @@ extern uint32_t get_page_dir(void);
 extern void _process_handler(void);
 extern void switch_task(uint32_t esp, uint32_t cr3, uint32_t *kernel_esp);
 
-
 void process_handler();
 
 uint32_t get_next_pid() {
@@ -14,6 +13,10 @@ uint32_t get_next_pid() {
 }
 
 struct process *running_proc;
+
+struct process *get_current_proc(void) {
+    return running_proc;
+}
 
 void proc_init() {
     struct process *kernel_proc = kmalloc(sizeof(struct process));

--- a/kernel/libk/vmem.c
+++ b/kernel/libk/vmem.c
@@ -1,0 +1,116 @@
+#include <arch/x86/process.h>
+#include <libk/kmem.h>
+#include <libk/lock.h>
+#include <libk/vmem.h>
+
+struct virt_region {
+    size_t size;
+    void *addr;
+    struct virt_region *next;
+};
+
+static inline struct virt_region *get_cur_free_regions(void) {
+    return get_current_proc()->free_virt;
+}
+
+static void map_region(void *vr, size_t pages,  uint16_t perms) {
+    for (void *addr = vr; addr < vr + (pages * PAGE_SIZE);
+            addr += PAGE_SIZE) {
+        inner_map_page(CUR_PAGE_DIRECTORY_ADDR, alloc_frame(), addr, perms);
+    }
+}
+
+static void unmap_region(void *vr, size_t pages) {
+    for (void *addr = vr; addr < vr + (pages * PAGE_SIZE);
+            addr += PAGE_SIZE) {
+        inner_unmap_page(CUR_PAGE_DIRECTORY_ADDR, addr, true);
+    }
+}
+
+// TODO: Make this an rb tree insertion. This is O(N) linked list insertion.
+// TODO: Implement region merging.
+static void insert_region(void *addr, size_t size, struct virt_region *vr) {
+    struct virt_region *prev = vr;
+    kassert(prev != NULL);
+    struct virt_region *cur = vr;
+    while (cur != NULL && size < cur->size) {
+        prev = cur;
+        cur = cur->next;
+    }
+    struct virt_region *new = kmalloc(sizeof(struct virt_region));
+    new->size = size;
+    new->addr = addr;
+    new->next = cur;
+    prev->next = new;
+}
+
+// TODO: Make this an rb tree walk. This is O(N) linked list traversal.
+static void *find_region(size_t size, struct virt_region *vr) {
+    struct virt_region *closest_prev = NULL;
+    struct virt_region *closest = NULL;
+    struct virt_region *prev = NULL;
+    struct virt_region *cur = vr;
+    size_t closest_size = SIZE_MAX;
+    while (cur->next != NULL && cur->size < cur->next->size) {
+        if (cur->size >= size && closest_size > cur->size - size) {
+            closest_size = cur->size;
+            closest = cur;
+            closest_prev = prev;
+        }
+        prev = cur;
+        cur = cur->next;
+    }
+    // If there isn't enough space.
+    if (closest == NULL) {
+        return NULL;
+    }
+    // Remove the closest match from the list.
+    if (closest_prev != NULL) {
+        closest_prev->next = closest->next;
+    }
+    // If the region is too big, split it and insert the smaller end into the
+    // list.
+    if (closest_size > size) {
+        void *split_addr = closest->addr + (size * PAGE_SIZE);
+        size_t split_size = closest->size - size;
+        closest->size = size;
+        insert_region(split_addr, split_size, vr);
+    }
+    void *addr = closest->addr;
+    kfree(closest);
+    return addr;
+}
+
+struct virt_region *init_free_list(void) {
+    struct virt_region *lower_half = kmalloc(sizeof(struct virt_region));
+    // Don't give out the NULL page.
+    lower_half->size = KERNEL_START - PAGE_SIZE;
+    lower_half->addr = NULL + PAGE_SIZE;
+    struct virt_region *higher_half = kmalloc(sizeof(struct virt_region));
+    higher_half->size = ((void*)~0) - KHEAP_PHYS_END;
+    higher_half->addr = KHEAP_PHYS_END;
+    higher_half->next = NULL;
+    lower_half->next = higher_half;
+    return lower_half;
+}
+
+void destroy_free_list(struct virt_region *vr) {
+    struct virt_region *cur = vr;
+    while (cur->next != NULL) {
+        struct virt_region *next = cur->next;
+        kfree(cur);
+        cur = next;
+    }
+    kfree(cur);
+}
+
+void *get_region(size_t pages, enum region_perms perms) {
+    void *addr = find_region(pages, get_cur_free_regions());
+    map_region(addr, alloc_frame(), (uint16_t)perms);
+    return addr;
+}
+
+void put_region(void *region, size_t pages) {
+    unmap_region(region, pages);
+    insert_region(region, pages, get_cur_free_regions());
+}

--- a/kernel/libk/vmem.c
+++ b/kernel/libk/vmem.c
@@ -10,7 +10,7 @@ struct virt_region {
 };
 
 static inline struct virt_region *get_cur_free_regions(void) {
-    return get_current_proc()->free_virt;
+    return get_current_proc()->memory.free_virt;
 }
 
 static void map_region(void *vr, size_t pages,  uint16_t perms) {


### PR DESCRIPTION
Write a per process virtual memory allocator.

We need to rewrite the `create_page_dir` and `kernel_page_table_install` functions.