### PR TITLE
Only cache compiler install artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
             - yasm
 cache:
     directories:
-        - compiler/
+        - compiler/i686-elf
 
 before_script:
     - virtualenv ~/venv


### PR DESCRIPTION
Do not cache sources or the build tree. This will hopefully make Travis CI runs
faster.